### PR TITLE
make reflective code work with jb/functions

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -123,22 +123,31 @@ function get_args(li::LambdaStaticData)
         argnames = map(u -> u.args[1], argnames)
     end
 
-    argnames
+    if _arg_offset == 0
+        return argnames
+    else
+        return argnames[_arg_offset:end]
+    end
 end
 
 function get_args(m::Method)
-    li = m.func.code
+    li = m.func
+    if !isa(li,LambdaStaticData)
+        li = li.code
+    end
     get_args(li)
 end
 
 function get_args(f::Function)
     try
-        get_args(f.env.defs.func)
+        get_args(first(methods(f)).func)
     catch e
         get_args(f.code)
     end
 end
 
+_arg_offset = 0
+_arg_offset = length(get_args(x->x))
 
 ## bind
 ## Function callbacks have first argument path that is ignored


### PR DESCRIPTION
This fixes Tk.jl's *horrible, evil* use of reflection to be forward compatible with jb/functions. I've confirmed that this works on 0.5-master both with and without jb/functions, and I'm almost certain it will work with 0.4 too.