### PR TITLE
WIP enabling Winston on 0.5

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -169,7 +169,6 @@ end
 _arg_offset = 0
 _arg_offset = length(get_args(x->x))
 
-
 ## bind
 ## Function callbacks have first argument path that is ignored
 ## others match percent substitution

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -38,10 +38,10 @@ function init()
     tclinterp = ccall((:Tcl_CreateInterp,libtcl), Ptr{Void}, ())
     @static if is_windows()
         htcl = ccall((:GetModuleHandleA,:kernel32),stdcall,Csize_t,
-            (Ptr{UInt8},),libtcl);
-        tclfile = Array(UInt8,260);
+            (Ptr{UInt8},),libtcl)
+        tclfile = Array(UInt8,260)
         len = ccall((:GetModuleFileNameA,:kernel32),stdcall,Cint,
-            (Csize_t,Ptr{UInt8},Cint),htcl,tclfile,length(tclfile));
+            (Csize_t,Ptr{UInt8},Cint),htcl,tclfile,length(tclfile))
         if len > 0
             tcldir = dirname(String(tclfile[1:len]))
             libpath = IOBuffer()
@@ -53,7 +53,7 @@ function init()
             print_escaped(libpath,abspath(tcldir,"..","share","tk"),"{}")
             print(libpath,"}]")
             tcl_eval(takebuf_string(libpath),tclinterp)
-        end;
+        end
     end
     if ccall((:Tcl_Init,libtcl), Int32, (Ptr{Void},), tclinterp) == TCL_ERROR
         throw(TclError(string("error initializing Tcl: ", tcl_result(tclinterp))))


### PR DESCRIPTION
i manually merged the solution to run Winston in 0.5 (with Tk) from
Pkg.clone("git@github.com:MetServiceDev/Tk.jl.git")
Pkg.clone("git@github.com:MetServiceDev/Winston.jl.git")

The change is only effective in get_args(::Function). Afaics Pkg.test on Tk (and Winston) succeeds.
