### PR TITLE
Updates for Julia 0.6, drop 0.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
     - linux
 julia:
-    - 0.4
     - 0.5
     - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Julia interface to the Tk windowing toolkit.
 
-[![Tk](http://pkg.julialang.org/badges/Tk_0.3.svg)](http://pkg.julialang.org/?pkg=Tk&ver=0.3)
-[![Tk](http://pkg.julialang.org/badges/Tk_0.4.svg)](http://pkg.julialang.org/?pkg=Tk&ver=0.4)
-[![Build Status](https://travis-ci.org/JuliaLang/Tk.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/Tk.jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaLang/Tk.jl/badge.svg)](https://coveralls.io/r/JuliaLang/Tk.jl)
+[![Tk](http://pkg.julialang.org/badges/Tk_0.5.svg)](http://pkg.julialang.org/?pkg=Tk)
+[![Tk](http://pkg.julialang.org/badges/Tk_0.6.svg)](http://pkg.julialang.org/?pkg=Tk)
+[![Build Status](https://travis-ci.org/JuliaGraphics/Tk.jl.svg?branch=master)](https://travis-ci.org/JuliaGraphics/Tk.jl)
+[![Coverage Status](https://coveralls.io/repos/JuliaGraphics/Tk.jl/badge.svg)](https://coveralls.io/r/JuliaGraphics/Tk.jl)
 
 The documentation for this package is in the `examples` directory.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.4
-Compat 0.7.20
+julia 0.5
+Compat 0.17.0
 Cairo
 Graphics 0.1
 BinDeps 0.2.2-

--- a/examples/manipulate.jl
+++ b/examples/manipulate.jl
@@ -25,7 +25,7 @@ using Winston
 end
 
 
-abstract ManipulateWidget
+@compat abstract type ManipulateWidget end
 get_label(widget::ManipulateWidget) = widget.label
 
 type SliderWidget <: ManipulateWidget

--- a/examples/workspace.jl
+++ b/examples/workspace.jl
@@ -15,7 +15,7 @@ short_summary(x) = summary(x)
 short_summary(x::AbstractString) = "A string"
 
 ## update ids, returning false if the same, true if not
-__ids__ = Array(AbstractString, 0)
+__ids__ = Vector{AbstractString}(0)
 function update_ids(m::Module)
     global __ids__
     nms = get_names(m)
@@ -31,8 +31,8 @@ end
 
 
 negate(x::Bool, val::Bool) = val ? !x : x
-MaybeRegex = (@compat Union{(@compat Void), Regex})
-MaybeType = (@compat Union{(@compat Void), DataType})
+const MaybeRegex = Union{Void, Regex}
+const MaybeType = Union{Void, DataType}
 
 ## get array of names and summaries
 ## m module

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -64,7 +64,7 @@ destroy(widget::Tk_Toplevel) = tcl("destroy", widget)
 ## Labelframe
 Labelframe(parent::Widget, text::AbstractString) = Labelframe(parent, text=text)
 get_value(widget::Tk_Labelframe) = cget(widget, "text")
-set_value(widget::Tk_Labelframe, text::AbstractString) = configure(widget, @compat Dict(:text=> text))
+set_value(widget::Tk_Labelframe, text::AbstractString) = configure(widget, Dict(:text=> text))
 
 ## Notebook
 function page_add(child::Widget, label::AbstractString)
@@ -132,7 +132,7 @@ function forget(parent::TTk_Container, child::Widget)
 end
 
 ## grid ...
-IntOrRange = (@compat Union{Integer, UnitRange})
+IntOrRange = Union{Integer, UnitRange}
 function grid(child::Widget, row::IntOrRange, column::IntOrRange; kwargs...)
     path = get_path(child)
     if isa(row, UnitRange) rowspan = 1 + maximum(row) - minimum(row)  else rowspan = 1 end
@@ -211,10 +211,10 @@ parent(w::Tk_Widget) = parent(w.w)
 parent(c::Canvas) = parent(c.c)
 
 # For toplevel it's obvious how to wrap it...
-function toplevel(w::(@compat Union{TkWidget, Tk_Widget, Canvas}))
+function toplevel(w::Union{TkWidget, Tk_Widget, Canvas})
     p = parent(w)
     pold = p
-    while !is(p, nothing)
+    while p !== nothing
         pold = p
         p = parent(p)
     end

--- a/src/dialogs.jl
+++ b/src/dialogs.jl
@@ -8,7 +8,7 @@ ChooseDirectory() = tcl("tk_chooseDirectory")
 ## Message box
 function Messagebox(parent::MaybeWidget; title::AbstractString="", message::AbstractString="", detail::AbstractString="")
     args = Dict()
-    if !isa(parent, (@compat Void)) args["parent"] = get_path(parent) end
+    if !isa(parent, Void) args["parent"] = get_path(parent) end
     if length(title) > 0 args["title"] = title  end
     if length(message) > 0 args["message"] = message end
     if length(detail) > 0 args["detail"] = detail end

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -39,7 +39,7 @@ function init()
     @static if is_windows()
         htcl = ccall((:GetModuleHandleA,:kernel32),stdcall,Csize_t,
             (Ptr{UInt8},),libtcl)
-        tclfile = Array(UInt8,260)
+        tclfile = Vector{UInt8}(260)
         len = ccall((:GetModuleFileNameA,:kernel32),stdcall,Cint,
             (Csize_t,Ptr{UInt8},Cint),htcl,tclfile,length(tclfile))
         if len > 0
@@ -103,7 +103,7 @@ end
 type TkWidget
     path::String
     kind::String
-    parent::(@compat Union{TkWidget,Void})
+    parent::Union{TkWidget,Void}
     
     let ID::Int = 0
     function TkWidget(parent::TkWidget, kind)
@@ -267,9 +267,9 @@ end
 
 @static if is_apple()
 if @compat Sys.WORD_SIZE == 32
-    typealias CGFloat Float32
+    const CGFloat = Float32
 else
-    typealias CGFloat Float64
+    const CGFloat = Float64
 end
 objc_msgSend{T}(id, uid, ::Type{T}=Ptr{Void}) = ccall(:objc_msgSend, T, (Ptr{Void}, Ptr{Void}),
     id, ccall(:sel_getUid, Ptr{Void}, (Ptr{UInt8},), uid))
@@ -368,7 +368,7 @@ function render_to_cairo(f::Function, w::TkWidget, clipped::Bool=true)
         return
     end
     @static if is_windows()
-        state = Array(UInt8, sizeof(Int)*2) # 8.4, 8.5, 8.6
+        state = Vector{UInt8}(sizeof(Int)*2) # 8.4, 8.5, 8.6
         drawable = jl_tkwin_id(win)
         hdc = ccall((:TkWinGetDrawableDC,libtk), Ptr{Void}, (Ptr{Void}, Int, Ptr{UInt8}),
             jl_tkwin_display(win), drawable, state)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,15 +1,15 @@
 ## Abstract types
-abstract Tk_Widget
-abstract TTk_Widget <: Tk_Widget ## for ttk::widgets
-abstract TTk_Container <: Tk_Widget ## for containers (frame, labelframe, ???)
+@compat abstract type Tk_Widget end
+@compat abstract type TTk_Widget <: Tk_Widget end ## for ttk::widgets
+@compat abstract type TTk_Container <: Tk_Widget end ## for containers (frame, labelframe, ???)
 
-Widget = (@compat Union{TkWidget, Tk_Widget, Canvas, AbstractString})
+const Widget = Union{TkWidget, Tk_Widget, Canvas, AbstractString}
 
 ## Maybe -- can this be parameterized?
 ## https://groups.google.com/forum/?fromgroups=#!topic/julia-dev/IbbWwplrqlc (takeaway -- this style is frowned upon)
-MaybeFunction = (@compat Union{Function, (@compat Void)})
-MaybeString = (@compat Union{AbstractString, (@compat Void)})
-MaybeStringInteger = (@compat Union{AbstractString, Integer, (@compat Void)}) # for at in tree insert
-MaybeVector = (@compat Union{Vector, (@compat Void)})
-MaybeWidget = (@compat Union{Widget, (@compat Void)})
-MaybeBool = (@compat Union{Bool, (@compat Void)})
+const MaybeFunction = Union{Function, Void}
+const MaybeString = Union{AbstractString, Void}
+const MaybeStringInteger = Union{AbstractString, Integer, Void} # for at in tree insert
+const MaybeVector = Union{Vector, Void}
+const MaybeWidget = Union{Widget, Void}
+const MaybeBool = Union{Bool, Void}

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -60,8 +60,8 @@ end
 Label(parent::Widget, text::AbstractString, image::Tk_Image) = Label(parent, text=tk_string_escape(text), image=image, compound="left")
 Label(parent::Widget, text::AbstractString) = Label(parent, text=tk_string_escape(text))
 Label(parent::Widget,  image::Tk_Image) = Label(parent, image=image, compound="image")
-get_value(widget::(@compat Union{Tk_Button, Tk_Label})) = widget[:text]
-function set_value(widget::(@compat Union{Tk_Label, Tk_Button}), value::AbstractString)
+get_value(widget::Union{Tk_Button, Tk_Label}) = widget[:text]
+function set_value(widget::Union{Tk_Label, Tk_Button}, value::AbstractString)
     variable = cget(widget, "textvariable")
     (variable == "") ? widget[:text] =  tk_string_escape(value) : tclvar(variable, value)
 end
@@ -103,7 +103,7 @@ set_items(widget::Tk_Checkbutton, value::AbstractString) = widget[:text] = tk_st
 type Tk_Radiobutton <: TTk_Widget
     w::TkWidget
 end
-MaybeTkRadioButton = (@compat Union{Void, Tk_Radiobutton})
+MaybeTkRadioButton = Union{Void, Tk_Radiobutton}
 
 function Radiobutton(parent::Widget, group::MaybeTkRadioButton, label::AbstractString)
 
@@ -125,12 +125,12 @@ set_items(widget::Tk_Radiobutton, value::AbstractString) = configure(widget, tex
 type Tk_Radio <: TTk_Widget
     w::TkWidget
     buttons::Vector
-    orient::(@compat Union{Void, AbstractString})
+    orient::Union{Void, AbstractString}
 end
 
 function Radio{T<:AbstractString}(parent::Widget, labels::Vector{T}, orient::AbstractString)
     n = size(labels)[1]
-    rbs = Array(Tk_Radiobutton, n)
+    rbs = Vector{Tk_Radiobutton}(n)
     frame = Frame(parent)
 
     rbs[1] = Radiobutton(frame, tk_string_escape(labels[1]))
@@ -314,7 +314,7 @@ get_value(widget::Tk_Progressbar) = round(Int, float(widget[:value]))
 set_value(widget::Tk_Progressbar, value::Integer) = widget[:value] = min(100, max(0, value))
 
 ## Image
-MaybeImage = (@compat Union{Void, Tk_Image})
+MaybeImage = Union{Void, Tk_Image}
 to_tcl(x::Tk_Image) = x.w
 
 function Image(fname::AbstractString)
@@ -440,7 +440,7 @@ type Tk_Treeview <: TTk_Widget
 end
 type TreeNode node::AbstractString end
 to_tcl(x::TreeNode) = x.node
-MaybeTreeNode = (@compat Union{TreeNode, Void})
+MaybeTreeNode = Union{TreeNode, Void}
 
 ## Special Tree cases
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,298 +1,321 @@
 ## Tests
 using Tk
-using Compat; import Compat.String
+using Base.Test
 
-## Toplevel
-w = Toplevel("Toplevel", 400, 400)
-set_position(w, 10, 10)
-@assert get_value(w) == "Toplevel"
-set_value(w, "Toplevel 2")
-@assert get_value(w) == "Toplevel 2"
-@assert get_size(w) == [400, 400]
-p = toplevel(w)
-@assert p == w
-destroy(w)
-@assert !exists(w)
+@testset "Toplevel" begin
+    w = Toplevel("Toplevel", 400, 400)
+    set_position(w, 10, 10)
+    @test get_value(w) == "Toplevel"
+    set_value(w, "Toplevel 2")
+    @test get_value(w) == "Toplevel 2"
+    @test get_size(w) == [400, 400]
+    p = toplevel(w)
+    @test p == w
+    destroy(w)
+    @test !exists(w)
+end
 
-## Frame
-w = Toplevel("Frame", 400, 400)
-pack_stop_propagate(w)
-f = Frame(w)
-pack(f, expand=true, fill="both")
-@assert get_size(w) == [400, 400]
-p = toplevel(f)
-@assert p == w
-destroy(w)
+@testset "Frame" begin
+    w = Toplevel("Frame", 400, 400)
+    pack_stop_propagate(w)
+    f = Frame(w)
+    pack(f, expand=true, fill="both")
+    @test get_size(w) == [400, 400]
+    p = toplevel(f)
+    @test p == w
+    destroy(w)
+end
 
-## Labelframe
-w = Toplevel("Labelframe", 400, 400)
-pack_stop_propagate(w)
-f = Labelframe(w, "Label")
-pack(f, expand=true, fill="both")
-set_value(f, "new label")
-@assert get_value(f) == "new label"
-p = toplevel(f)
-@assert p == w
-destroy(w)
+@testset "Labelframe" begin
+    w = Toplevel("Labelframe", 400, 400)
+    pack_stop_propagate(w)
+    f = Labelframe(w, "Label")
+    pack(f, expand=true, fill="both")
+    set_value(f, "new label")
+    @test get_value(f) == "new label"
+    p = toplevel(f)
+    @test p == w
+    destroy(w)
+end
 
-## notebook
-w = Toplevel("Notebook")
-nb = Notebook(w); pack(nb, expand=true, fill="both")
-page_add(Button(nb, "one"), "tab one")
-page_add(Button(nb, "two"), "tab two")
-page_add(Button(nb, "three"), "tab three")
-@assert Tk.no_tabs(nb) == 3
-set_value(nb, 2)
-@assert get_value(nb) == 2
-destroy(w)
+@testset "Notebook" begin
+    w = Toplevel("Notebook")
+    nb = Notebook(w); pack(nb, expand=true, fill="both")
+    page_add(Button(nb, "one"), "tab one")
+    page_add(Button(nb, "two"), "tab two")
+    page_add(Button(nb, "three"), "tab three")
+    @test Tk.no_tabs(nb) == 3
+    set_value(nb, 2)
+    @test get_value(nb) == 2
+    destroy(w)
+end
 
-## Panedwindow
-w = Toplevel("Panedwindow", 400, 400)
-pack_stop_propagate(w)
-pw = Panedwindow(w, "horizontal"); pack(pw, expand=true, fill="both")
-page_add(Button(pw, "one"), 1)
-page_add(Button(pw, "two"), 1)
-page_add(Button(pw, "three"), 1)
-set_value(pw, 100)
-destroy(w)
+@testset "Panedwindow" begin
+    w = Toplevel("Panedwindow", 400, 400)
+    pack_stop_propagate(w)
+    pw = Panedwindow(w, "horizontal"); pack(pw, expand=true, fill="both")
+    page_add(Button(pw, "one"), 1)
+    page_add(Button(pw, "two"), 1)
+    page_add(Button(pw, "three"), 1)
+    set_value(pw, 100)
+    destroy(w)
+end
 
-## pack Anchor
-w = Toplevel("Anchor argument", 500, 500)
-pack_stop_propagate(w)
-f = Frame(w, padding = [3,3,12,12]); pack(f, expand = true, fill = "both")
-tr = Frame(f); mr = Frame(f); br = Frame(f)
-map(u -> pack(u, expand =true, fill="both"), (tr, mr, br))
-pack(Label(tr, "nw"), anchor = "nw", expand = true, side = "left")
-pack(Label(tr, "n"),  anchor = "n",  expand = true, side = "left")
-pack(Label(tr, "ne"), anchor = "ne", expand = true, side = "left")
-##
-pack(Label(mr, "w"),       anchor = "w",       expand =true, side ="left")
-pack(Label(mr, "center"),  anchor = "center",  expand =true, side ="left")
-pack(Label(mr, "e"),       anchor = "e",       expand =true, side ="left")
-##
-pack(Label(br, "sw"), anchor = "sw", expand = true,  side = "left")
-pack(Label(br, "s"),  anchor = "s",  expand = true,  side = "left")
-pack(Label(br, "se"), anchor = "se", expand = true,  side = "left")
-destroy(w)
+@testset "pack Anchor" begin
+    w = Toplevel("Anchor argument", 500, 500)
+    pack_stop_propagate(w)
+    f = Frame(w, padding = [3,3,12,12]); pack(f, expand = true, fill = "both")
+    tr = Frame(f); mr = Frame(f); br = Frame(f)
+    map(u -> pack(u, expand =true, fill="both"), (tr, mr, br))
+    pack(Label(tr, "nw"), anchor = "nw", expand = true, side = "left")
+    pack(Label(tr, "n"),  anchor = "n",  expand = true, side = "left")
+    pack(Label(tr, "ne"), anchor = "ne", expand = true, side = "left")
+    ##
+    pack(Label(mr, "w"),       anchor = "w",       expand =true, side ="left")
+    pack(Label(mr, "center"),  anchor = "center",  expand =true, side ="left")
+    pack(Label(mr, "e"),       anchor = "e",       expand =true, side ="left")
+    ##
+    pack(Label(br, "sw"), anchor = "sw", expand = true,  side = "left")
+    pack(Label(br, "s"),  anchor = "s",  expand = true,  side = "left")
+    pack(Label(br, "se"), anchor = "se", expand = true,  side = "left")
+    destroy(w)
+end
 
 ## example of last in first covered
 ## Create this GUI, then shrink window with the mouse
-w = Toplevel("Last in, first covered", 400, 400)
-f = Frame(w)
+@testset "Last in, first covered" begin
+    w = Toplevel("Last in, first covered", 400, 400)
+    f = Frame(w)
 
-g1 = Frame(f)
-g2 = Frame(f)
-map(u -> pack(u, expand=true, fill="both"), (f, g1, g2))
+    g1 = Frame(f)
+    g2 = Frame(f)
+    map(u -> pack(u, expand=true, fill="both"), (f, g1, g2))
 
-b11 = Button(g1, "first")
-b12 = Button(g1, "second")
-b21 = Button(g2, "first")
-b22 = Button(g2, "second")
+    b11 = Button(g1, "first")
+    b12 = Button(g1, "second")
+    b21 = Button(g2, "first")
+    b22 = Button(g2, "second")
 
-map(u -> pack(u, side="left"),  (b11, b12))
-map(u -> pack(u, side="right"), (b21, b22))
-## Now shrink window
-destroy(w)
-
-
-## Grid
-w = Toplevel("Grid", 400, 400)
-pack_stop_propagate(w)
-f = Frame(w); pack(f, expand=true, fill="both")
-grid(Slider(f, 1:10, orient="vertical"), 1:3, 1)
-grid(Slider(f, 1:10), 1  , 2:3, sticky="news")
-grid(Button(f, "2,2"), 2  , 2)
-grid(Button(f, "2,3"), 2  , 3)
-destroy(w)
-
-## Formlayout
-w = Toplevel("Formlayout")
-f = Frame(w); pack(f, expand=true, fill="both")
-map(u -> formlayout(Entry(f, u), u), ["one", "two", "three"])
-destroy(w)
-
-## Widgets
-
-## button, label
-w = Toplevel("Widgets")
-f = Frame(w); pack(f, expand=true, fill="both")
-l = Label(f, "label")
-b = Button(f, "button")
-map(pack, (l, b))
-
-set_value(l, "new label")
-@assert get_value(l) == "new label"
-set_value(b, "new label")
-@assert get_value(b) == "new label"
-ctr = 1
-function cb(path)
-    global ctr
-    ctr = ctr + 1
+    map(u -> pack(u, side="left"),  (b11, b12))
+    map(u -> pack(u, side="right"), (b21, b22))
+    ## Now shrink window
+    destroy(w)
 end
-bind(b, "command", cb)
-tcl(b, "invoke")
-@assert ctr == 2
-img = Image(joinpath(dirname(@__FILE__), "..", "examples", "weather-overcast.gif"))
-map(u-> configure(u, image=img, compound="left"), (l,b))
-destroy(w)
-
-## checkbox
-w = Toplevel("Checkbutton")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-check = Checkbutton(f, "check me"); pack(check)
-set_value(check, true)
-@assert get_value(check) == true
-set_items(check, "new label")
-@assert get_items(check) == "new label"
-ctr = 1
-bind(check, "command", cb)
-tcl(check, "invoke")
-@assert ctr == 2
-destroy(w)
-
-## radio
-choices = ["choice one", "choice two", "choice three"]
-w = Toplevel("Radio")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-r = Radio(f, choices); pack(r)
-set_value(r, choices[1])
-@assert get_value(r) == choices[1]
-set_value(r, 2)                         #  by index
-@assert get_value(r) == choices[2]
-@assert get_items(r) == choices
-destroy(w)
-
-## combobox
-w = Toplevel("Combobox")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-combo = Combobox(f, choices); pack(combo)
-set_editable(combo, false)              # default
-set_value(combo, choices[1])
-@assert get_value(combo) == choices[1]
-set_value(combo, 2)                         #  by index
-@assert get_value(combo) == choices[2]
-set_value(combo, nothing)
-@assert get_value(combo) == nothing
-set_items(combo, map(uppercase, choices))
-set_value(combo, 2)
-@assert get_value(combo) == uppercase(choices[2])
-set_items(combo, @compat Dict(:one=>"ONE", :two=>"TWO"))
-set_value(combo, "one")
-@assert get_value(combo) == "one"
-destroy(w)
 
 
-## slider
-w = Toplevel("Slider")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-sl = Slider(f, 1:10, orient="vertical"); pack(sl)
-set_value(sl, 3)
-@assert get_value(sl) == 3
-bind(sl, "command", cb) ## can't test
-destroy(w)
-
-## spinbox
-w = Toplevel("Spinbox")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-sp = Spinbox(f, 1:10); pack(sp)
-set_value(sp, 3)
-@assert get_value(sp) == 3
-destroy(w)
-
-## progressbar
-w = Toplevel("Progress bar")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-pb = Progressbar(f, orient="horizontal"); pack(pb)
-set_value(pb, 50)
-@assert get_value(pb) == 50
-configure(pb, mode = "indeterminate")
-destroy(w)
-
-
-## Entry
-w = Toplevel("Entry")
-f = Frame(w)
-pack(f, expand=true, fill="both")
-e = Entry(f, "initial"); pack(e)
-set_value(e, "new text")
-@assert get_value(e) == "new text"
-set_value(e, "[1,2,3]")
-@assert get_value(e) == "[1,2,3]"
-set_visible(e, false)
-set_visible(e, true)
-## Validation
-function validatecommand(path, s, S)
-    println("old $s, new $S")
-    s == "invalid" ? tcl("expr", "FALSE") : tcl("expr", "TRUE")     # *must* return logical in this way
+@testset "Grid" begin
+    w = Toplevel("Grid", 400, 400)
+    pack_stop_propagate(w)
+    f = Frame(w); pack(f, expand=true, fill="both")
+    grid(Slider(f, 1:10, orient="vertical"), 1:3, 1)
+    grid(Slider(f, 1:10), 1  , 2:3, sticky="news")
+    grid(Button(f, "2,2"), 2  , 2)
+    grid(Button(f, "2,3"), 2  , 3)
+    destroy(w)
 end
-function invalidcommand(path, W)
-    println("called when invalid")
-    tcl(W, "delete", "@0", "end")
-    tcl(W, "insert", "@0", "new text")
+
+@testset "Formlayout" begin
+    w = Toplevel("Formlayout")
+    f = Frame(w); pack(f, expand=true, fill="both")
+    map(u -> formlayout(Entry(f, u), u), ["one", "two", "three"])
+    destroy(w)
 end
-configure(e, validate="key", validatecommand=validatecommand, invalidcommand=invalidcommand)
-destroy(w)
 
-## Text
-w = Toplevel("Text")
-pack_stop_propagate(w)
-f = Frame(w); pack(f, expand=true, fill="both")
-txt = Text(f)
-scrollbars_add(f, txt)
-set_value(txt, "new text\n")
-@assert get_value(txt) == "new text\n"
-set_value(txt, "[1,2,3]")
-@assert get_value(txt) == "[1,2,3]"
-destroy(w)
+@testset "Widgets" begin
+    global ctr = 1
+    function cb(path)
+        global ctr
+        ctr += 1
+    end
+    global choices = ["choice one", "choice two", "choice three"]
 
-## tree. Listbox
-w = Toplevel("Listbox")
-pack_stop_propagate(w)
-f = Frame(w); pack(f, expand=true, fill="both")
-tr = Treeview(f, choices)
-## XXX scrollbars_add(f, tr)
-set_value(tr, 2)
-@assert get_value(tr)[1] == choices[2]
-set_items(tr, choices[1:2])
-destroy(w)
+    @testset "button, label" begin
+        w = Toplevel("Widgets")
+        f = Frame(w); pack(f, expand=true, fill="both")
+        l = Label(f, "label")
+        b = Button(f, "button")
+        map(pack, (l, b))
 
-## tree grid
-w = Toplevel("Array")
-pack_stop_propagate(w)
-f = Frame(w); pack(f, expand=true, fill="both")
-tr = Treeview(f, hcat(choices, choices))
-tree_key_header(tr, "right"); tree_key_width(tr, 50)
-tree_headers(tr, ["left"], [50])
-scrollbars_add(f, tr)
-set_value(tr, 2)
-@assert get_value(tr)[1] == choices[2]
-destroy(w)
+        set_value(l, "new label")
+        @test get_value(l) == "new label"
+        set_value(b, "new label")
+        @test get_value(b) == "new label"
 
-## Canvas
-w = Toplevel("Canvas")
-pack_stop_propagate(w)
-f = Frame(w); pack(f, expand=true, fill="both")
-c = Canvas(f)
-@assert parent(c) == f.w
-@assert toplevel(c) == w
-destroy(w)
+        bind(b, "command", cb)
+        tcl(b, "invoke")
+        @test ctr == 2
+        img = Image(joinpath(dirname(@__FILE__), "..", "examples", "weather-overcast.gif"))
+        map(u-> configure(u, image=img, compound="left"), (l,b))
+        destroy(w)
+    end
+
+    @testset "checkbox" begin
+        w = Toplevel("Checkbutton")
+        f = Frame(w)
+        pack(f, expand=true, fill="both")
+        check = Checkbutton(f, "check me"); pack(check)
+        set_value(check, true)
+        @test get_value(check) == true
+        set_items(check, "new label")
+        @test get_items(check) == "new label"
+        ctr = 1
+        bind(check, "command", cb)
+        tcl(check, "invoke")
+        @test ctr == 2
+        destroy(w)
+    end
+
+    @testset "radio" begin
+        w = Toplevel("Radio")
+        f = Frame(w)
+        pack(f, expand=true, fill="both")
+        r = Radio(f, choices); pack(r)
+        set_value(r, choices[1])
+        @test get_value(r) == choices[1]
+        set_value(r, 2)                         #  by index
+        @test get_value(r) == choices[2]
+        @test get_items(r) == choices
+        destroy(w)
+    end
+
+    @testset "combobox" begin
+        w = Toplevel("Combobox")
+        f = Frame(w)
+        pack(f, expand=true, fill="both")
+        combo = Combobox(f, choices); pack(combo)
+        set_editable(combo, false)              # default
+        set_value(combo, choices[1])
+        @test get_value(combo) == choices[1]
+        set_value(combo, 2)                         #  by index
+        @test get_value(combo) == choices[2]
+        set_value(combo, nothing)
+        @test get_value(combo) == nothing
+        set_items(combo, map(uppercase, choices))
+        set_value(combo, 2)
+        @test get_value(combo) == uppercase(choices[2])
+        set_items(combo, Dict(:one=>"ONE", :two=>"TWO"))
+        set_value(combo, "one")
+        @test get_value(combo) == "one"
+        destroy(w)
+    end
+
+    @testset "slider" begin
+        w = Toplevel("Slider")
+        f = Frame(w)
+        pack(f, expand=true, fill="both")
+        sl = Slider(f, 1:10, orient="vertical"); pack(sl)
+        set_value(sl, 3)
+        @test get_value(sl) == 3
+        bind(sl, "command", cb) ## can't test
+        destroy(w)
+    end
+
+    @testset "spinbox" begin
+        w = Toplevel("Spinbox")
+        f = Frame(w)
+        pack(f, expand=true, fill="both")
+        sp = Spinbox(f, 1:10); pack(sp)
+        set_value(sp, 3)
+        @test get_value(sp) == 3
+        destroy(w)
+    end
+
+    @testset "progressbar" begin
+        w = Toplevel("Progress bar")
+        f = Frame(w)
+        pack(f, expand=true, fill="both")
+        pb = Progressbar(f, orient="horizontal"); pack(pb)
+        set_value(pb, 50)
+        @test get_value(pb) == 50
+        configure(pb, mode = "indeterminate")
+        destroy(w)
+    end
+end
+
+@testset "Entry" begin
+    w = Toplevel("Entry")
+    f = Frame(w)
+    pack(f, expand=true, fill="both")
+    e = Entry(f, "initial"); pack(e)
+    set_value(e, "new text")
+    @test get_value(e) == "new text"
+    set_value(e, "[1,2,3]")
+    @test get_value(e) == "[1,2,3]"
+    set_visible(e, false)
+    set_visible(e, true)
+    ## Validation
+    function validatecommand(path, s, S)
+        println("old $s, new $S")
+        s == "invalid" ? tcl("expr", "FALSE") : tcl("expr", "TRUE")     # *must* return logical in this way
+    end
+    function invalidcommand(path, W)
+        println("called when invalid")
+        tcl(W, "delete", "@0", "end")
+        tcl(W, "insert", "@0", "new text")
+    end
+    configure(e, validate="key", validatecommand=validatecommand, invalidcommand=invalidcommand)
+    destroy(w)
+end
+
+@testset "Text" begin
+    w = Toplevel("Text")
+    pack_stop_propagate(w)
+    f = Frame(w); pack(f, expand=true, fill="both")
+    txt = Text(f)
+    scrollbars_add(f, txt)
+    set_value(txt, "new text\n")
+    @test get_value(txt) == "new text\n"
+    set_value(txt, "[1,2,3]")
+    @test get_value(txt) == "[1,2,3]"
+    destroy(w)
+end
+
+@testset "tree. Listbox" begin
+    w = Toplevel("Listbox")
+    pack_stop_propagate(w)
+    f = Frame(w); pack(f, expand=true, fill="both")
+    tr = Treeview(f, choices)
+    ## XXX scrollbars_add(f, tr)
+    set_value(tr, 2)
+    @test get_value(tr)[1] == choices[2]
+    set_items(tr, choices[1:2])
+    destroy(w)
+end
+
+@testset "tree grid" begin
+    w = Toplevel("Array")
+    pack_stop_propagate(w)
+    f = Frame(w); pack(f, expand=true, fill="both")
+    tr = Treeview(f, hcat(choices, choices))
+    tree_key_header(tr, "right"); tree_key_width(tr, 50)
+    tree_headers(tr, ["left"], [50])
+    scrollbars_add(f, tr)
+    set_value(tr, 2)
+    @test get_value(tr)[1] == choices[2]
+    destroy(w)
+end
+
+@testset "Canvas" begin
+    w = Toplevel("Canvas")
+    pack_stop_propagate(w)
+    f = Frame(w); pack(f, expand=true, fill="both")
+    c = Canvas(f)
+    @test parent(c) == f.w
+    @test toplevel(c) == w
+    destroy(w)
+end
 
 ## Examples
 # Wrap each test in its own module to avoid namespace leaks between files
 const exampledir = joinpath(splitdir(splitdir(@__FILE__)[1])[1], "examples")
 dcur = pwd()
 cd(exampledir)
-module example_manipulate
-    if Pkg.installed("Winston")!=nothing
-        include("../examples/manipulate.jl")
-    end
-end
+# TODO: Uncomment when Winston supports 0.6
+#module example_manipulate
+#    if Pkg.installed("Winston")!=nothing
+#        include("../examples/manipulate.jl")
+#    end
+#end
 module example_process
     include("../examples/process.jl")
 end


### PR DESCRIPTION
This PR removes unnecessary `@compat`s, adds some necessary `@compat`s, drops support for 0.4, and facilitates support for 0.6.