### PR TITLE
Fix 0.6 ccall on OS X and add OS X to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 os:
     - linux
+    - osx
 julia:
     - 0.5
     - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ notifications:
     email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.clone("Winston")'
-    - xvfb-run julia -e 'Pkg.build("Tk"); Pkg.test("Tk"; coverage=true)';
+    - julia -e 'Pkg.clone(pwd())'
+    - if [ `uname` = "Linux" ]; then
+        xvfb-run julia -e 'Pkg.build("Tk"); Pkg.test("Tk"; coverage=true)';
+      elif [ `uname` = "Darwin" ]; then
+        julia -e 'Pkg.build("Tk"); Pkg.test("Tk"; coverage=true)';
+      fi
     # - xvfb-run julia -e 'Pkg.clone(pwd()); Pkg.build("Tk"); Pkg.test("Tk"; coverage=true)';
 after_success:
     - julia -e 'cd(Pkg.dir("Tk")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -266,7 +266,7 @@ function reveal(c::Canvas)
 end
 
 @static if is_apple()
-    if @compat Sys.WORD_SIZE == 32
+    if Sys.WORD_SIZE == 32
         const CGFloat = Float32
     else
         const CGFloat = Float64

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -266,13 +266,15 @@ function reveal(c::Canvas)
 end
 
 @static if is_apple()
-if @compat Sys.WORD_SIZE == 32
-    const CGFloat = Float32
-else
-    const CGFloat = Float64
-end
-objc_msgSend{T}(id, uid, ::Type{T}=Ptr{Void}) = ccall(:objc_msgSend, T, (Ptr{Void}, Ptr{Void}),
-    id, ccall(:sel_getUid, Ptr{Void}, (Ptr{UInt8},), uid))
+    if @compat Sys.WORD_SIZE == 32
+        const CGFloat = Float32
+    else
+        const CGFloat = Float64
+    end
+    function objc_msgSend{T}(id, uid, ::Type{T}=Ptr{Void})
+        convert(T, ccall(:objc_msgSend, Ptr{Void}, (Ptr{Void}, Ptr{Void}),
+                         id, ccall(:sel_getUid, Ptr{Void}, (Ptr{UInt8},), uid)))
+    end
 end
 
 # NOTE: This has to be ported to each window environment.


### PR DESCRIPTION
Currently the definition of `objc_msgSend` causes `TypeError: ccall method definition: expected Type, got TypeVar` on Julia 0.6 OS X. This wasn't caught presumably because OS X isn't enabled on Travis, so I've enabled it.