### PR TITLE
Rename `Text` to `TkText`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ Constructors are provided  for the following widgets
 * `Frame`, `Labelframe`, `Notebook`, `Panedwindow`: for the basic containers
 * `Label`, `Button`, `Menu`: basic elements
 * `Checkbutton`, `Radio`, `Combobox`, `Slider`, `Spinbox`: selection widgets
-* `Entry`, `Text`: text widgets
+* `Entry`, `TkText`: text widgets
 * `Treeview`: for trees, but also listboxes and grids
 * `Sizegrip`, `Separator`, `Progressbar`, `Image` various widgets
 
@@ -387,7 +387,7 @@ The basic multi-line text widget can be done through:
 w = Toplevel()
 tcl("pack", "propagate", w, false)
 f = Frame(w)
-txt = Text(f)
+txt = TkText(f)
 scrollbars_add(f, txt)
 pack(f, expand=true, fill = "both")
 ```

--- a/examples/process.jl
+++ b/examples/process.jl
@@ -1,3 +1,5 @@
+using Compat
+
 f = "radio.png"
 
 function process_file(f)
@@ -5,4 +7,4 @@ function process_file(f)
     "<!-- $f -->\n<img src='data:image/png;base64,$a'></img>"
 end
 
-process_file(f)
+@compat is_windows() || process_file(f)

--- a/src/Tk.jl
+++ b/src/Tk.jl
@@ -24,7 +24,7 @@ else
     error("Tk not properly installed. Please run Pkg.build(\"Tk\")")
 end
 
-import Base: ==, bind, getindex, isequal, parent, setindex!, show, string, Text
+import Base: ==, bind, getindex, isequal, parent, setindex!, show, string
 
 if VERSION < v"0.4.0-dev+3275"
     import Base.Graphics: width, height, getgc
@@ -55,7 +55,7 @@ export Toplevel, Frame, Labelframe, Notebook, Panedwindow
 export Label, Button
 export Checkbutton, Radio, Combobox
 export Slider, Spinbox
-export Entry, set_validation, Text
+export Entry, set_validation, TkText
 export Treeview, selected_nodes, node_insert, node_move, node_delete, node_open
 export tree_headers, tree_column_widths, tree_key_header, tree_key_width
 export Sizegrip, Separator, Progressbar, Image, Scrollbar

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -183,7 +183,7 @@ end
 ##
 ## w = Toplevel()
 ## f = Frame(w); pack(f) ## f shouldn't have any layout management of its children
-## t = Text(f)
+## t = TkText(f)
 ## scrollbars_add(f,t)
 ##
 function scrollbars_add(parent::Tk_Frame, child::Tk_Widget)
@@ -233,5 +233,3 @@ function children(w::TTk_Container; ismapped::Bool=false)
     end
     kids
 end
-
-

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -46,13 +46,13 @@ function init()
             tcldir = dirname(String(tclfile[1:len]))
             libpath = IOBuffer()
             print(libpath,"set env(TCL_LIBRARY) [subst -nocommands -novariables {")
-            print_escaped(libpath,abspath(tcldir,"..","share","tcl"),"{}")
+            escape_string(libpath,abspath(tcldir,"..","share","tcl"),"{}")
             print(libpath,"}]")
-            tcl_eval(takebuf_string(libpath),tclinterp)
+            @compat tcl_eval(String(take!(libpath)),tclinterp)
             print(libpath,"set env(TK_LIBRARY) [subst -nocommands -novariables {")
-            print_escaped(libpath,abspath(tcldir,"..","share","tk"),"{}")
+            escape_string(libpath,abspath(tcldir,"..","share","tk"),"{}")
             print(libpath,"}]")
-            tcl_eval(takebuf_string(libpath),tclinterp)
+            @compat tcl_eval(String(take!(libpath)),tclinterp)
         end
     end
     if ccall((:Tcl_Init,libtcl), Int32, (Ptr{Void},), tclinterp) == TCL_ERROR
@@ -104,7 +104,7 @@ type TkWidget
     path::String
     kind::String
     parent::Union{TkWidget,Void}
-    
+
     let ID::Int = 0
     function TkWidget(parent::TkWidget, kind)
         underscoredKind = replace(kind, "::", "_")

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -34,7 +34,7 @@ for (k, k1, v) in ((:Label, :Tk_Label, "ttk::label"),
                    (:Menu, :Tk_Menu, "menu"),
                    (:Menubutton, :Tk_Menubutton, "ttk::menubutton"),
                    (:Scrollbar, :Tk_Scrollbar, "ttk::scrollbar"),
-                   (:Text, :Tk_Text, "text"),
+                   (:TkText, :Tk_Text, "text"),
                    (:Treeview, :Tk_Treeview, "ttk::treeview"),
                    (:TkCanvas, :Tk_Canvas, "canvas"),
                    ##
@@ -672,4 +672,3 @@ function Canvas(parent::TTk_Container, args...)
     push!(parent.children, Tk_CairoCanvas(c))
     c
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 ## Tests
 using Tk
 using Base.Test
+using Compat
 
 @testset "Toplevel" begin
     w = Toplevel("Toplevel", 400, 400)
@@ -144,8 +145,8 @@ end
         bind(b, "command", cb)
         tcl(b, "invoke")
         @test ctr == 2
-        path = join([dirname(@__FILE__), "..", "examples", "weather-overcast.gif"], '/')
-        if is_windows()
+        path = joinpath(dirname(@__FILE__), "..", "examples", "weather-overcast.gif")
+        @compat if is_windows()
           path = replace(path, r"\\", "/")
         end
         img = Image(path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,7 +144,11 @@ end
         bind(b, "command", cb)
         tcl(b, "invoke")
         @test ctr == 2
-        img = Image(joinpath(dirname(@__FILE__), "..", "examples", "weather-overcast.gif"))
+        path = join([dirname(@__FILE__), "..", "examples", "weather-overcast.gif"], '/')
+        if is_windows()
+          path = replace(path, r"\\", "/")
+        end
+        img = Image(path)
         map(u-> configure(u, image=img, compound="left"), (l,b))
         destroy(w)
     end
@@ -257,11 +261,11 @@ end
     destroy(w)
 end
 
-@testset "Text" begin
+@testset "TkText" begin
     w = Toplevel("Text")
     pack_stop_propagate(w)
     f = Frame(w); pack(f, expand=true, fill="both")
-    txt = Text(f)
+    txt = TkText(f)
     scrollbars_add(f, txt)
     set_value(txt, "new text\n")
     @test get_value(txt) == "new text\n"


### PR DESCRIPTION
and fix test errors on Windows and 0.6.

Fixes #117.