### PR TITLE
fix print_escaped and takebuf_string

### DIFF
--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -46,13 +46,13 @@ function init()
             tcldir = dirname(String(tclfile[1:len]))
             libpath = IOBuffer()
             print(libpath,"set env(TCL_LIBRARY) [subst -nocommands -novariables {")
-            print_escaped(libpath,abspath(tcldir,"..","share","tcl"),"{}")
+            escape_string(libpath,abspath(tcldir,"..","share","tcl"),"{}")
             print(libpath,"}]")
-            tcl_eval(takebuf_string(libpath),tclinterp)
+            tcl_eval(String(take!(libpath)),tclinterp)
             print(libpath,"set env(TK_LIBRARY) [subst -nocommands -novariables {")
-            print_escaped(libpath,abspath(tcldir,"..","share","tk"),"{}")
+            escape_string(libpath,abspath(tcldir,"..","share","tk"),"{}")
             print(libpath,"}]")
-            tcl_eval(takebuf_string(libpath),tclinterp)
+            tcl_eval(String(take!(libpath)),tclinterp)
         end
     end
     if ccall((:Tcl_Init,libtcl), Int32, (Ptr{Void},), tclinterp) == TCL_ERROR
@@ -194,7 +194,8 @@ type MouseHandler
                          default_mouse_cb, default_mouse_cb)
 end
 
-# TkCanvas is the plain Tk canvas widget. This one is double-buffered
+# TkCanvas is the plain Tk canvas widget. This one is double-
+ed
 # and built on Cairo.
 type Canvas
     c::TkWidget

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -194,8 +194,7 @@ type MouseHandler
                          default_mouse_cb, default_mouse_cb)
 end
 
-# TkCanvas is the plain Tk canvas widget. This one is double-
-ed
+# TkCanvas is the plain Tk canvas widget. This one is double-buffered
 # and built on Cairo.
 type Canvas
     c::TkWidget


### PR DESCRIPTION
`print_escaped` fails on 0.6 and `takebuf_string` is deprecated.
I am not sure how much backward compatibility should be ensured in the code but without the first change `Tk.jl` will not load on 0.6.